### PR TITLE
Simplify clean function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,29 +22,12 @@ interface Options {
 function clean(txt: string, options?: Options) {
   if (typeof txt !== 'string') throw new Error('Parameter txt must be a string !');
 
-  const capitalizeFirstLetter =
-    options &&
-    typeof options === 'object' &&
-    options.capitalizeFirstLetter &&
-    typeof options.capitalizeFirstLetter === 'boolean'
-      ? options.capitalizeFirstLetter
-      : false;
-
-  const capitalizeAllWords =
-    options &&
-    typeof options === 'object' &&
-    options.capitalizeAllWords &&
-    typeof options.capitalizeAllWords === 'boolean'
-      ? options.capitalizeAllWords
-      : false;
-
-  const keepUnrecognized =
-    options && typeof options === 'object' && options.keepUnrecognized && typeof options.keepUnrecognized === 'boolean'
-      ? options.keepUnrecognized
-      : false;
+  const capitalizeFirstLetter = options && options.capitalizeFirstLetter;
+  const capitalizeAllWords = options && options.capitalizeAllWords;
+  const keepUnrecognized = options && options.keepUnrecognized;
 
   const results = [...txt]
-    .map((char) => (characters[char] ? characters[char] : keepUnrecognized ? char : ''))
+    .map((char) => characters[char] || (keepUnrecognized ? char : ''))
     .join('')
     .trim();
 


### PR DESCRIPTION
I think the long chain of `options && typeof options === 'object' && options.foo && type options.foo === 'boolean' ? options.foo : false` can definitely be simplified. Also, `x ? x : y` can be refactored to just `x || y`,